### PR TITLE
set up authorisations

### DIFF
--- a/src/Controller/TaskController.php
+++ b/src/Controller/TaskController.php
@@ -45,19 +45,25 @@ class TaskController extends AbstractController
     #[Route('/tasks/edit/{id}', name: 'task_edit', methods: ['GET', 'POST'])]
     public function editAction(Task $task, Request $request, EntityManagerInterface $em): Response
     {
+        $author = $task->getUser();
+        $connectedUser = $this->getUser();
+        $roles = $this->getUser()->getRoles();
+        $username = $task->getUser()->getUsername();
+
         $form = $this->createForm(TaskType::class, $task);
 
         $form->handleRequest($request);
 
-        if ($form->isSubmitted() && $form->isValid()) {
+        if (($form->isSubmitted() && $form->isValid()) && (($author == $connectedUser) || (in_array('ROLE_ADMIN', $roles) && $username == 'anonyme'))){
+
             $em->flush();
 
             $this->addFlash('success', 'La tâche a bien été modifiée.');
 
             return $this->redirectToRoute('task_list');
         }
-
         return $this->render('task/edit.html.twig', [
+            
             'form' => $form->createView(),
             'task' => $task,
         ]);
@@ -66,22 +72,44 @@ class TaskController extends AbstractController
     #[Route('/tasks/{id}/toggle', name: 'task_toggle')]
     public function toggleTaskAction(Task $task, EntityManagerInterface $em)
     {
+        $author = $task->getUser();
+        $connectedUser = $this->getUser();
+        $roles = $this->getUser()->getRoles();
+        $username = $task->getUser()->getUsername();
+
+        if (($author == $connectedUser) || (in_array('ROLE_ADMIN', $roles) && $username == 'anonyme')){
+
         $task->toggle(!$task->isDone());
         $em->flush();
 
         $this->addFlash('success', sprintf('La tâche %s a bien été marquée comme faite.', $task->getTitle()));
 
+        }else {
+            $this->addFlash('error', "Vous n'avez pas les droits pour marquer comme faite cette tâche");
+        }
         return $this->redirectToRoute('task_list');
     }
 
     #[Route('/tasks/{id}/delete', name: 'task_delete')]
     public function deleteTaskAction(Task $task, EntityManagerInterface $em)
     {
+        $author = $task->getUser();
+        $connectedUser = $this->getUser();
+        $roles = $this->getUser()->getRoles();
+        $username = $task->getUser()->getUsername();
+
+        if (($author == $connectedUser) || (in_array('ROLE_ADMIN', $roles) && $username == 'anonyme')){
+
         $em->remove($task);
         $em->flush();
 
         $this->addFlash('success', 'La tâche a bien été supprimée.');
 
+        }else {
+            $this->addFlash('error', "Vous n'avez pas les droits pour supprimer cette tâche");
+        }
         return $this->redirectToRoute('task_list');
+
+
     }
 }


### PR DESCRIPTION
- only admins can access users management pages
- tasks can be deleted only by users who created those tasks
- Tasks attached to the “anonymous” user can only be deleted by users with the administrator role (ROLE_ADMIN).